### PR TITLE
Added ImagesLoaded.js to fix overlapping images in Chrome bug.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 	"minimum-stability": "stable",
 	"require": {
 		"yiisoft/yii2": "*",
-		"bower-asset/masonry" : "*"
+		"bower-asset/masonry" : "*",
+		"bower-asset/imagesloaded" : "*"
 	},
 	"autoload": {
 		"psr-4": { "yii2masonry\\": "" }

--- a/yii2masonry.php
+++ b/yii2masonry.php
@@ -77,6 +77,8 @@ class yii2masonry extends Widget
         $options = Json::encode($this->clientOptions);
         $js[] = "var mscontainer$id = document.querySelector('#$id');";
         $js[] = "var msnry$id = new Masonry( mscontainer$id, $options);";
+        $js[] = "imagesLoaded( mscontainer$id, function() {  msnry$id.layout(); });";
+
         
         $view->registerJs(implode("\n", $js),View::POS_READY);
     }

--- a/yii2masonryAsset.php
+++ b/yii2masonryAsset.php
@@ -22,6 +22,7 @@ class yii2masonryAsset extends AssetBundle
     public $css = array();
     
     public $js = array(
+        'imagesloaded.pkgd.min.js',
         'masonry.pkgd.js'
     );
 


### PR DESCRIPTION
This adds a call to masonry.layout() after all the images have finished loading. 

I'm not sure I got the package management right, I'm not familiar with composer and bower. yii2masonryAsset.php may have to be adjusted for the proper filename. 
