### PR TITLE
Add on readme a configuration if exist a sidebar resizeble

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ $this->registerJs($script, View::POS_READY);
 ```
 My button have an ID name #menu_toggle
 
-Sample with INFINITE SCROLL:
+***INFINITE SCROLL***
+Sample:
 ```php
 use yii\helpers\Html;
 use yii\widgets\ListView;

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ On a page with a ListView, just add:
 <?php \yii2masonry\yii2masonry::end(); ?>
 
 ```
+**CSS**
 
 Size of columns can be defined within css
 ```css
@@ -78,7 +79,21 @@ Size of columns can be defined within css
   .item.w2 { width: 50%; } //not important if you not use infinite scroll
 ```
 
-Sample with infinity scroll:
+If you have a sidebar resizeble by a button you need to reload the masonry container adding these following code:
+```php
+<?php
+$script = <<< JS
+    $('a#menu_toggle').on('click', function() {
+        $('.js-masonry').masonry();
+    });
+JS;
+$this->registerJs($script, View::POS_READY);
+?>
+  
+```
+My button have an ID name #menu_toggle
+
+Sample with INFINITE SCROLL:
 ```php
 use yii\helpers\Html;
 use yii\widgets\ListView;

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ On a page with a ListView, just add:
 
 Size of columns can be defined within css
 ```css
-  .item { width: 25%; } //important to define width of all item
-  .item.w2 { width: 50%; } //not important if you not use infinite scroll
+  .item { width: 25%; } 
+  .item.w2 { width: 50%; }
 ```
 
 If you have a sidebar resizeble by a button you need to reload the masonry container adding these following code:

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ On a page with a ListView, just add:
 
 Size of columns can be defined within css
 ```css
-  .item { width: 25%; }
-  .item.w2 { width: 50%; }
+  .item { width: 25%; } //important to define width of all item
+  .item.w2 { width: 50%; } //not important if you not use infinite scroll
 ```
 
 Sample with infinity scroll:


### PR DESCRIPTION
There's a bugfix on masonry when there's a sidebar resizeble.
To reload the masonry container when sidebar is resized on click event in a button is neccessary to add a simple code at the end of page like these.

<?php
$script = <<< JS
    $('a#menu_toggle').on('click', function() {
        $('.js-masonry').masonry();
    });
JS;
$this->registerJs($script, View::POS_READY);
?>